### PR TITLE
Adds Jinja2 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+jinja2


### PR DESCRIPTION
In a blank virtualenv Jinja2 is not installed, but seems to be needed. This adds it to the requirements.txt.