### PR TITLE
Get narator ready for the cheese shop

### DIFF
--- a/narator/__init__.py
+++ b/narator/__init__.py
@@ -1,0 +1,12 @@
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+def get_template():
+    """\
+    Returns the default narator template from the package.
+    """
+    env = Environment(
+        loader=PackageLoader('narator', 'templates'),
+        autoescape=select_autoescape(['txt'])
+    )
+
+    return env.get_template('template.txt')

--- a/narator/narator
+++ b/narator/narator
@@ -1,19 +1,15 @@
-import re
-import requests
-from requests.auth import HTTPBasicAuth
-import argparse
+#! /usr/bin/env python3
+
 import os
+import re
+import argparse
+import requests
+
 from urllib.parse import urlparse
-from jinja2 import Environment, PackageLoader, select_autoescape
+from requests.auth import HTTPBasicAuth
 
+from narator import get_template
 
-def get_template():
-    env = Environment(
-        loader=PackageLoader('narator', 'templates'),
-        autoescape=select_autoescape(['txt'])
-    )
-
-    return env.get_template('template.txt')
 
 
 def new_topic():

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 setup(
     name='narator',
     packages=['narator'],
+    scripts=['narator/narator'],
     version='0.1',
     description='',
     url='',
@@ -11,11 +12,12 @@ setup(
     author_email='dincamihai@gmail.com',
     license='MIT',
     include_package_data=True,
-    package_data = {
+    package_data={
         'narator': ['templates/*']
-    }
+    },
     install_requires=[
-        "jinja2"
+        "jinja2",
+        "requests"
     ],
     tests_requires=[
         'pytest',


### PR DESCRIPTION
With these changes narator can be pushed to pypi.org.

* Executalbe was renamed to `narator` instead of `narator.py` and is marked as a script.
* `get_template()` found a new home in the `__init__.py`, so that the template folder can be found.
* Added `requests` as a requirement in `setup.py`.